### PR TITLE
remove window set up on settings page

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { WebviewWindow } from "@tauri-apps/api/window";
+
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/tauri";
 import BackButton from "@/components/ui/back-button";
@@ -92,25 +92,16 @@ function APIKeySet({ onSetEditable }: { onSetEditable: any }) {
 }
 
 export default function SettingsPage() {
-  // Set up app window
-  const [appWindow, setAppWindow] = useState<WebviewWindow>();
   const [appSettings, setAppSettings] = useState<AppSettings>({
     apiKey: "",
     model: "",
-  });
-  async function setupAppWindow() {
-    const appWindow = (await import("@tauri-apps/api/window")).appWindow;
-    setAppWindow(appWindow);
-  }
+  })
 
-  // Set up router
   const router = useRouter();
 
-  // Set up API key editability
   const [isEditable, setIsEditable] = useState<boolean>();
 
   useEffect(() => {
-    setupAppWindow();
     invoke<AppSettings>("get_settings").then((settings) => {
       setAppSettings(settings);
       settings.apiKey ? setIsEditable(false) : setIsEditable(true);


### PR DESCRIPTION
## Description
- The settings page used to directly read the settings from the frontend. To make it work with Next, there was some window setup to access the file.
- Now the settings are retrieved from the backend, so the this setup is unnecessary. So it is removed